### PR TITLE
Fix: Add null check for cursor.fetchone() in _table_exists method

### DIFF
--- a/db_handler.py
+++ b/db_handler.py
@@ -34,7 +34,8 @@ class DatabaseHandler:
         """
         with self.connection.cursor() as cursor:
             cursor.execute(check_sql, [table_name.upper()])
-            count = cursor.fetchone()[0]
+            result = cursor.fetchone()
+            count = result[0] if result else 0
             return count > 0
 
     def _create_table(self):


### PR DESCRIPTION
## Bug Fix: Missing null check before cursor.fetchone() dereference

### Problem
In the `_table_exists` method of `DatabaseHandler`, `cursor.fetchone()` can return `None` when no rows are found, causing a `TypeError` when accessing the `[0]` index.

### Solution
Added a null check before dereferencing the result of `cursor.fetchone()`:

```python
result = cursor.fetchone()
count = result[0] if result else 0
```

### Impact
- Prevents `TypeError: 'NoneType' object is not subscriptable` when the query returns no rows
- Ensures robust database operations even in edge cases
- Maintains backward compatibility with existing functionality

### Testing
The fix handles the case where `user_tables` query returns no matching rows gracefully, returning `False` for `_table_exists()` as expected.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.